### PR TITLE
docs: add blog posts for November 2025 releases

### DIFF
--- a/docs/blog/2025-11-28-fragments-system.md
+++ b/docs/blog/2025-11-28-fragments-system.md
@@ -1,0 +1,174 @@
+# 2025-11-28 — Fragments System: Bootstrap Projects in Minutes
+
+## What Shipped
+
+- **Fragments system** - Reusable project scaffolds for consistent infrastructure
+- **nx-dev-infra fragment** - Containerized Nx development environment (Node 22 + pnpm + Nx + Postgres + n8n)
+- **apply-nx-dev-infra.sh** - One-command bootstrapping script
+- **Fragments guide** - Comprehensive 270-line documentation
+- **Expanded mission** - `.pip` now provides docs AND executable scaffolding
+
+## Why It Matters
+
+### The Problem
+Every time you start a new project (web app, mobile app, API, service), you spend hours setting up the same infrastructure:
+- Nx monorepo configuration
+- Docker development environment
+- PostgreSQL database
+- n8n workflow automation
+- Project structure and tooling
+
+This repetitive work wastes time and leads to inconsistencies across projects.
+
+### The Solution
+Fragments let you bootstrap any project type with **one command**:
+
+```bash
+# In your new project
+git submodule add git@github.com:derrybirkett/pip.git .pip
+./.pip/bin/apply-nx-dev-infra.sh
+
+# 30 seconds later...
+nx run infra:up
+docker exec -it monospace-dev bash
+```
+
+### The Impact
+- ⚡ **10x faster** - Minutes instead of hours to working environment
+- 🔄 **Consistent** - Same patterns across all projects
+- 📦 **Portable** - Works on any machine with Docker
+- 🎯 **Focused** - Spend time building features, not infrastructure
+
+## How It Works
+
+### Fragments are Scaffolds
+A fragment is a collection of files that get copied into your project:
+- `Dockerfile.dev` - Development container config
+- `docker-compose.yml` - Multi-service orchestration
+- `tools/infra/project.json` - Nx targets for container management
+
+### Apply Once, Own Forever
+When you apply a fragment:
+1. Files are copied to your project
+2. You own them and can customize
+3. No automatic updates (intentional)
+4. Simple, predictable, no magic
+
+### Example: nx-dev-infra Fragment
+
+**What you get:**
+- **Dev container** - Node 22, pnpm, Nx pre-installed
+- **PostgreSQL 16** - Database ready at `localhost:5432`
+- **n8n** - Workflow automation at `localhost:5678`
+- **Nx targets** - `infra:up`, `infra:down`, `infra:logs`
+
+**Usage:**
+```bash
+# Start everything
+nx run infra:up
+
+# Enter dev container
+docker exec -it monospace-dev bash
+
+# Inside container, you have full Nx workspace
+pnpm install
+nx serve web
+nx run api:serve
+nx run mobile:start
+```
+
+## Architecture Decisions
+
+### Why Fragments Over Templates?
+- **Simpler** - Just bash scripts and file copying
+- **Transparent** - See exactly what files you're getting
+- **Flexible** - Edit after applying, no framework lock-in
+- **Composable** - Apply multiple fragments to same project
+
+### Why in .pip Repo?
+- **Single source** - Documentation + executable patterns together
+- **Consistent** - Fragments implement patterns docs describe
+- **Convenient** - One git submodule gets you everything
+
+### Why "Apply Once"?
+- **Clear ownership** - Files belong to your project after applying
+- **No surprises** - No automatic updates breaking your customizations
+- **Simple mental model** - Copy files, done
+
+## What's Coming Next
+
+### Planned Fragments
+Based on common app patterns, we'll add:
+- **next-web** - Next.js web app with ShadCN UI
+- **expo-mobile** - Expo mobile app (iOS + Android)
+- **api-graphql** - GraphQL API service
+- **agent-service** - AI agent microservice
+
+### Future Enhancements
+- **pip CLI tool** - `pip apply nx-dev-infra` instead of path to script
+- **Fragment versioning** - Choose which version to apply
+- **Template variables** - Customize project names, ports, etc.
+- **Fragment composition** - Dependencies between fragments
+
+## Real-World Example
+
+**Before fragments:**
+```bash
+# Day 1: Research and setup
+- Find Docker + Nx guides
+- Configure Dockerfile
+- Set up docker-compose
+- Install Nx
+- Configure Postgres
+- Set up n8n
+- Debug connection issues
+- Document for team
+
+# Result: 1-2 days lost, inconsistent across projects
+```
+
+**With fragments:**
+```bash
+# Day 1: Build features
+git init my-app && cd my-app
+git submodule add git@github.com:derrybirkett/pip.git .pip
+./.pip/bin/apply-nx-dev-infra.sh
+nx run infra:up
+
+# 5 minutes later: coding actual features
+nx g @nx/next:app web
+nx serve web
+```
+
+## Try It Now
+
+### Quick Start
+```bash
+mkdir my-new-app
+cd my-new-app
+git init
+git submodule add git@github.com:derrybirkett/pip.git .pip
+./.pip/bin/apply-nx-dev-infra.sh
+nx run infra:up
+```
+
+### Learn More
+- [Fragments Guide](../fragments-guide.md) - Complete documentation
+- [nx-dev-infra README](../../fragments/nx-dev-infra/README.md) - Fragment details
+- [WARP.md](../../WARP.md) - Repository overview
+
+## Feedback Welcome
+
+This is the MVP - one fragment, simple bash script. We want to learn:
+- Which fragments would be most valuable?
+- What customizations do you need?
+- Should we build the generic `pip` CLI tool?
+- What other pain points can we solve?
+
+## Links
+
+- Changelog: [../changelog.md](../changelog.md)
+- Fragments Guide: [../fragments-guide.md](../fragments-guide.md)
+- nx-dev-infra Fragment: [../../fragments/nx-dev-infra/README.md](../../fragments/nx-dev-infra/README.md)
+- Apply Script: [../../bin/apply-nx-dev-infra.sh](../../bin/apply-nx-dev-infra.sh)
+- Plan Document: Plan ID 633fd28f-f4ce-4fe3-8163-2f594e39cc0b

--- a/docs/blog/2025-11-28-warp-md-and-secure-env.md
+++ b/docs/blog/2025-11-28-warp-md-and-secure-env.md
@@ -1,0 +1,71 @@
+# 2025-11-28 — WARP.md & Secure Environment Setup
+
+## What Shipped
+
+- **WARP.md** - Comprehensive guidance file for AI agents working in `.pip` repository
+- **.envrc.example** - Template for secure environment variable management with direnv
+- **Environment setup documentation** - Added setup instructions to README.md
+- **Security fix** - Removed exposed Atlassian token, replaced with secure template approach
+
+## Why It Matters
+
+### For AI Agents
+WARP.md provides AI agents (like Warp's Agent Mode) with everything they need to work effectively in the repository:
+- Repository overview and structure
+- Git workflow and branching strategy
+- Required processes (activity log, changelog, wrap-up)
+- Quick reference commands
+- Key agent documents and navigation
+
+This means future AI assistance will be more accurate, follow established patterns, and understand the repository's governance model.
+
+### For Security
+The `.envrc.example` template approach eliminates accidentally committing secrets:
+- Example file is committed, actual `.envrc` is gitignored
+- Clear instructions for users to copy and populate
+- Uses direnv for automatic environment loading
+- Follows security best practices
+
+### For Onboarding
+New team members or contributors can quickly understand:
+- How the repository is organized
+- What processes to follow
+- Where to find key documentation
+- How to set up their environment securely
+
+## Key Features
+
+### WARP.md Contents
+- **Repository Overview** - What `.pip` is and its purpose
+- **Key Concepts** - Agent roles, critical files, directory structure
+- **Git Workflow** - Branching, commits, PRs, merging, releases
+- **Required Process** - Activity log, changelog, blog posts, testing
+- **Quick Reference** - Common tasks and commands
+- **Important Reminders** - From user rules and governance
+
+### Environment Setup
+```bash
+# Copy example file
+cp .envrc.example .envrc
+
+# Add your secrets
+vim .envrc
+
+# Allow direnv to load
+direnv allow
+```
+
+## What's Next
+
+With proper AI agent guidance in place, we can:
+- Build more features with consistent patterns
+- Ensure agents follow security best practices
+- Maintain high-quality documentation
+- Scale collaboration with AI assistance
+
+## Links
+
+- Changelog: [../changelog.md](../changelog.md)
+- WARP.md: [../../WARP.md](../../WARP.md)
+- Environment Setup: [../../README.md](../../README.md)
+- .envrc.example: [../../.envrc.example](../../.envrc.example)


### PR DESCRIPTION
## Goal
Add blog posts for the two major releases on 2025-11-28: WARP.md and Fragments System.

## Changes Made
-  - Blog post covering WARP.md and environment setup
-  - Blog post covering fragments system with nx-dev-infra

## Why
Per CMO responsibilities and wrap-up process, blog posts are required for new features. These posts:
- Explain what shipped and why it matters
- Provide usage examples and quick starts
- Link to relevant documentation
- Set context for future enhancements

## Checklist
- [x] Blog posts follow TEMPLATE.md format
- [x] Links to changelog and docs included
- [x] Written from user perspective
- [x] Examples and quick starts provided