### PR TITLE
fix: Jekyll build output path for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,15 +28,18 @@ jobs:
           bundler-cache: true
       
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v4
       
       - name: Build with Jekyll
-        run: bundle exec jekyll build
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
 
   deploy:
     environment:


### PR DESCRIPTION
## Issue

Blog site showing 404 error at https://derrybirkett.github.io/pip/

## Fix

Added explicit path specification for Jekyll build output:
- Set `id` on Setup Pages step to capture base path
- Pass base path to Jekyll build command
- Specify `path: ./_site` in upload artifact step

This ensures the built Jekyll site (_site directory) is properly uploaded and deployed to GitHub Pages.

## Testing

After merge, the workflow will rebuild and the blog should be live at https://derrybirkett.github.io/pip/

---

**Co-Authored-By**: Warp <agent@warp.dev>