### PR TITLE
fix: Use default layout for blog homepage

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -1,11 +1,22 @@
 ---
-layout: home
+layout: default
 title: .pip Framework Blog
 ---
 
 # Building Agentic Development Systems
 
 Latest insights on AI agent coordination, design patterns, and development workflows.
+
+## Latest Posts
+
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+    </li>
+  {% endfor %}
+</ul>
 
 ---
 


### PR DESCRIPTION
## Issue

Blog homepage showing 404 at https://derrybirkett.github.io/pip/ but individual posts work fine.

## Root Cause

The `home` layout wasn't rendering properly, causing the homepage to fail.

## Fix

Changed `index.md` to use `default` layout with explicit post list using Jekyll's Liquid syntax:

```html
<ul>
  {% for post in site.posts %}
    <li>
      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
      <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
    </li>
  {% endfor %}
</ul>
```

This manually renders the post list instead of relying on the `home` layout's automatic behavior.

## Result

Homepage will now display with a list of all 5 blog posts.

---

**Co-Authored-By**: Warp <agent@warp.dev>