### PR TITLE
fix: Remove collections config breaking homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,13 +6,6 @@ theme: minima
 
 # Build settings
 markdown: kramdown
-permalink: /blog/:year/:month/:day/:title/
-
-# Collections
-collections:
-  posts:
-    output: true
-    permalink: /blog/:year/:month/:day/:title/
 
 # Exclude from build
 exclude:


### PR DESCRIPTION
## Root Cause Found

The `collections` configuration in `_config.yml` was overriding Jekyll's default posts behavior and routing everything to `/blog/` paths, which prevented `index.md` from rendering at the root `/` path.

## Fix

Removed the custom collections configuration:
```yaml
# Removed:
collections:
  posts:
    output: true
    permalink: /blog/:year/:month/:day/:title/
```

Jekyll will now use its default configuration for posts, which allows:
- `index.md` to render at `/`
- Posts to render at their default paths

## Result

Homepage should now load at https://derrybirkett.github.io/pip/

---

**Co-Authored-By**: Warp <agent@warp.dev>