### PR TITLE
fix: Add proper Jekyll frontmatter to all blog posts

### DIFF
--- a/_posts/2025-12-01-interactive-bootstrap.md
+++ b/_posts/2025-12-01-interactive-bootstrap.md
@@ -1,8 +1,12 @@
-# Interactive Bootstrap: From User Story to Project in 60 Seconds
+---
+title: "Interactive Bootstrap: From User Story to Project in 60 Seconds"
+description: "New interactive wizard captures your user story and generates personalized project documentation in 60 seconds"
+date: 2025-12-01
+author: "CTO Agent"
+tags: ["bootstrap", "user-stories", "workflow", "v0.3.0"]
+---
 
-**Date:** 2025-12-01  
-**Version:** v0.3.0  
-**Feature:** Interactive Project Bootstrap Wizard
+# Interactive Bootstrap: From User Story to Project in 60 Seconds
 
 ## What's New
 

--- a/_posts/2025-12-09-branch-protection-enforcement.md
+++ b/_posts/2025-12-09-branch-protection-enforcement.md
@@ -1,8 +1,12 @@
-# Branch Protection: Learning from Mistakes
+---
+title: "Branch Protection: Learning from Mistakes"
+description: "Implementing git hooks and GitHub branch protection to prevent direct commits to main branch"
+date: 2025-12-09
+author: "CTO Agent"
+tags: ["git", "branch-protection", "workflow", "automation"]
+---
 
-**Date:** 2025-12-09  
-**Version:** Post-PR #10  
-**Feature:** Git Hooks + GitHub Branch Protection
+# Branch Protection: Learning from Mistakes
 
 ## The Mistake That Made This Necessary
 

--- a/_posts/2025-12-17-agentic-design-patterns.md
+++ b/_posts/2025-12-17-agentic-design-patterns.md
@@ -1,9 +1,12 @@
-# Agentic Design Patterns: Building Intelligence into .pip
+---
+title: "Agentic Design Patterns: Building Intelligence into .pip"
+description: "5 foundational agentic design patterns extracted from research, providing structured decision-making for AI agents"
+date: 2025-12-17
+author: "CTO Agent"
+tags: ["patterns", "agentic-systems", "phase-1", "v1.1.0"]
+---
 
-**Date**: December 17, 2025  
-**Author**: CTO Agent  
-**Tags**: patterns, agentic-systems, phase-1, v1.1.0  
-**Related**: MSTUDIO-56, ROADMAP.md
+# Agentic Design Patterns: Building Intelligence into .pip
 
 ## TL;DR
 

--- a/_posts/2025-12-19-agent-workflow-documents.md
+++ b/_posts/2025-12-19-agent-workflow-documents.md
@@ -1,8 +1,12 @@
-# Agent Workflow Documents: Making Patterns Practical
+---
+title: "Agent Workflow Documents: Making Patterns Practical"
+description: "Comprehensive workflow documents for all 5 primary agents showing how to apply agentic design patterns in daily work"
+date: 2025-12-19
+author: "CTO Agent"
+tags: ["agentic-patterns", "workflows", "agent-coordination", "phase-1"]
+---
 
-**Date**: 2025-12-19  
-**Author**: CTO Agent  
-**Tags**: agentic-patterns, workflows, agent-coordination, phase-1
+# Agent Workflow Documents: Making Patterns Practical
 
 ## TL;DR
 


### PR DESCRIPTION
## Problem

The blog posts weren't being generated by Jekyll because they lacked proper YAML frontmatter. Jekyll requires posts to start with frontmatter between `---` delimiters, but our posts were using markdown-style metadata instead.

## Solution

Added proper Jekyll frontmatter to all 4 posts that were missing it:
- `2025-12-19-agent-workflow-documents.md`
- `2025-12-17-agentic-design-patterns.md`
- `2025-12-01-interactive-bootstrap.md`
- `2025-12-09-branch-protection-enforcement.md`

Each post now has:
- `title` - Post title in quotes
- `description` - Short description for SEO/previews
- `date` - Publication date (YYYY-MM-DD format)
- `author` - Author name in quotes
- `tags` - Array of tag strings

## Example

**Before:**
```markdown
# Agent Workflow Documents: Making Patterns Practical

**Date**: 2025-12-19  
**Author**: CTO Agent  
**Tags**: agentic-patterns, workflows, agent-coordination, phase-1
```

**After:**
```markdown
---
title: "Agent Workflow Documents: Making Patterns Practical"
description: "Comprehensive workflow documents for all 5 primary agents..."
date: 2025-12-19
author: "CTO Agent"
tags: ["agentic-patterns", "workflows", "agent-coordination", "phase-1"]
---

# Agent Workflow Documents: Making Patterns Practical
```

## Testing

Once merged, the GitHub Pages workflow will regenerate the site with Jekyll properly processing the posts.

## Related

- Fixes the 404 errors on all blog post URLs
- Completes the Jekyll blog setup started in PR #25