### PR TITLE
fix: Correct permalink URLs to match Jekyll default structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="refresh" content="0; url=/pip/blog/2025/12/19/agent-workflow-documents/">
+    <meta http-equiv="refresh" content="0; url=/pip/2025/12/19/agent-workflow-documents/">
     <title>.pip Framework Blog</title>
     <style>
         body {
@@ -21,15 +21,15 @@
 <body>
     <h1>.pip Framework Blog</h1>
     <p>Building Agentic Development Systems</p>
-    <p>Redirecting to latest post... If not redirected, <a href="/pip/blog/2025/12/19/agent-workflow-documents/">click here</a>.</p>
+    <p>Redirecting to latest post... If not redirected, <a href="/pip/2025/12/19/agent-workflow-documents/">click here</a>.</p>
     
     <h2>All Posts</h2>
     <ul>
-        <li><a href="/pip/blog/2025/12/19/agent-workflow-documents/">Agent Workflow Documents: Making Patterns Practical</a> - Dec 19, 2025</li>
-        <li><a href="/pip/blog/2025/12/17/agentic-design-patterns/">Agentic Design Patterns</a> - Dec 17, 2025</li>
-        <li><a href="/pip/blog/2025/12/11/astro-blog-fragment/">Astro Blog Fragment</a> - Dec 11, 2025</li>
-        <li><a href="/pip/blog/2025/12/09/branch-protection-enforcement/">Branch Protection Enforcement</a> - Dec 9, 2025</li>
-        <li><a href="/pip/blog/2025/12/01/interactive-bootstrap/">Interactive Bootstrap</a> - Dec 1, 2025</li>
+        <li><a href="/pip/2025/12/19/agent-workflow-documents/">Agent Workflow Documents: Making Patterns Practical</a> - Dec 19, 2025</li>
+        <li><a href="/pip/2025/12/17/agentic-design-patterns/">Agentic Design Patterns</a> - Dec 17, 2025</li>
+        <li><a href="/pip/2025/12/11/astro-blog-fragment/">Astro Blog Fragment</a> - Dec 11, 2025</li>
+        <li><a href="/pip/2025/12/09/branch-protection-enforcement/">Branch Protection Enforcement</a> - Dec 9, 2025</li>
+        <li><a href="/pip/2025/12/01/interactive-bootstrap/">Interactive Bootstrap</a> - Dec 1, 2025</li>
     </ul>
     
     <p><a href="https://github.com/derrybirkett/pip">View Repository on GitHub</a></p>


### PR DESCRIPTION
## Problem

The index.html redirect URLs were using `/pip/blog/:year/:month/:day/:title/` but Jekyll's default permalink structure is `/:year/:month/:day/:title/` (without the `/blog/` segment).

This caused the redirect to briefly show the index page before redirecting to a 404.

## Solution

Removed `/blog/` from all permalink URLs in `index.html`:

**Before:**
```html
<meta http-equiv="refresh" content="0; url=/pip/blog/2025/12/19/agent-workflow-documents/">
<a href="/pip/blog/2025/12/19/agent-workflow-documents/">...</a>
```

**After:**
```html
<meta http-equiv="refresh" content="0; url=/pip/2025/12/19/agent-workflow-documents/">
<a href="/pip/2025/12/19/agent-workflow-documents/">...</a>
```

## Testing

Once merged and the GitHub Pages workflow completes, the blog should be accessible at:
- Homepage: https://derrybirkett.github.io/pip/
- Latest post: https://derrybirkett.github.io/pip/2025/12/19/agent-workflow-documents/
- All other posts: https://derrybirkett.github.io/pip/:year/:month/:day/:title/