### PR TITLE
fix: disable excerpts to remove TL;DR text from home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,8 +52,8 @@ feed:
   path: feed.xml
 
 # Excerpts
-show_excerpts: true
-excerpt_length: 30
+show_excerpts: false
+excerpt_length: 0
 
 # Pagination
 paginate: 10


### PR DESCRIPTION
Removes the TL;DR excerpt text that was appearing between posts on the home page.

## Change
- Set `show_excerpts: false` in `_config.yml`
- Set `excerpt_length: 0`

## Result
Home page now displays clean list of:
- ✅ Post title
- ✅ Date
- ❌ No excerpt/TL;DR text

Cleaner, more minimalist appearance matching Hitchens theme aesthetic.

Co-Authored-By: Warp <agent@warp.dev>