### PR TITLE
fix: add layout: post to all blog posts for proper styling

### DIFF
--- a/_posts/2025-12-01-interactive-bootstrap.md
+++ b/_posts/2025-12-01-interactive-bootstrap.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: "Interactive Bootstrap: From User Story to Project in 60 Seconds"
 description: "New interactive wizard captures your user story and generates personalized project documentation in 60 seconds"
 date: 2025-12-01

--- a/_posts/2025-12-09-branch-protection-enforcement.md
+++ b/_posts/2025-12-09-branch-protection-enforcement.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: "Branch Protection: Learning from Mistakes"
 description: "Implementing git hooks and GitHub branch protection to prevent direct commits to main branch"
 date: 2025-12-09

--- a/_posts/2025-12-11-astro-blog-fragment.md
+++ b/_posts/2025-12-11-astro-blog-fragment.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: "Astro Blog Fragment: Content Marketing Made Simple"
 description: "New fragment enables one-command blog setup with Astro, Tailwind CSS, and SEO optimization"
 date: 2025-12-11

--- a/_posts/2025-12-17-agentic-design-patterns.md
+++ b/_posts/2025-12-17-agentic-design-patterns.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: "Agentic Design Patterns: Building Intelligence into .pip"
 description: "5 foundational agentic design patterns extracted from research, providing structured decision-making for AI agents"
 date: 2025-12-17

--- a/_posts/2025-12-19-agent-workflow-documents.md
+++ b/_posts/2025-12-19-agent-workflow-documents.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: "Agent Workflow Documents: Making Patterns Practical"
 description: "Comprehensive workflow documents for all 5 primary agents showing how to apply agentic design patterns in daily work"
 date: 2025-12-19

--- a/_posts/2025-12-19-autonomous-review-and-unified-cli.md
+++ b/_posts/2025-12-19-autonomous-review-and-unified-cli.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: "Autonomous Progress Review System & Unified CLI"
 description: "Built an autonomous system that reviews progress and recommends priorities, plus a unified pip CLI demonstrating all 5 agentic design patterns working together"
 date: 2025-12-19


### PR DESCRIPTION
Fixes individual post pages not rendering with Hitchens theme styles.

## Root Cause
Post pages were missing `layout: post` in front matter, causing Jekyll to render them without the theme's styling.

## Change
Added `layout: post` to front matter of all 6 blog posts:
- 2025-12-01-interactive-bootstrap.md
- 2025-12-09-branch-protection-enforcement.md
- 2025-12-11-astro-blog-fragment.md
- 2025-12-17-agentic-design-patterns.md
- 2025-12-19-agent-workflow-documents.md
- 2025-12-19-autonomous-review-and-unified-cli.md

## Result
✅ Post pages now properly styled with Hitchens theme  
✅ Typography, spacing, and layout match theme design  
✅ Consistent appearance across all pages

Co-Authored-By: Warp <agent@warp.dev>