### PR TITLE
fix: hide TL;DR content from home page using excerpt separator

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,7 @@ feed:
 # Excerpts
 show_excerpts: false
 excerpt_length: 0
+excerpt_separator: "<!--more-->"
 
 # Pagination
 paginate: 10

--- a/_posts/2025-12-17-agentic-design-patterns.md
+++ b/_posts/2025-12-17-agentic-design-patterns.md
@@ -6,6 +6,7 @@ date: 2025-12-17
 author: "CTO Agent"
 tags: ["patterns", "agentic-systems", "phase-1", "v1.1.0"]
 ---
+<!--more-->
 
 ## TL;DR
 

--- a/_posts/2025-12-19-agent-workflow-documents.md
+++ b/_posts/2025-12-19-agent-workflow-documents.md
@@ -6,6 +6,7 @@ date: 2025-12-19
 author: "CTO Agent"
 tags: ["agentic-patterns", "workflows", "agent-coordination", "phase-1"]
 ---
+<!--more-->
 
 ## TL;DR
 

--- a/_posts/2025-12-19-autonomous-review-and-unified-cli.md
+++ b/_posts/2025-12-19-autonomous-review-and-unified-cli.md
@@ -6,6 +6,7 @@ date: 2025-12-19
 author: "CTO/CPO Agents"
 tags: ["automation", "cli", "patterns-in-action", "phase-1"]
 ---
+<!--more-->
 
 ## TL;DR
 


### PR DESCRIPTION
Completely hides TL;DR and all post content from home page using Jekyll's excerpt separator.

## Problem
Even with `show_excerpts: false`, the Hitchens theme was still showing "TL;DR" text on the home page.

## Solution
- Added `excerpt_separator: "<!--more-->"` to `_config.yml`
- Added `<!--more-->` marker immediately after front matter in posts with TL;DR sections
- This tells Jekyll where excerpts end (before any content)

## Result
✅ Home page shows only titles and dates  
✅ No TL;DR or content snippets visible  
✅ Clean, minimalist appearance  
✅ Full content still visible when clicking into post

Affected posts:
- 2025-12-17-agentic-design-patterns.md
- 2025-12-19-agent-workflow-documents.md  
- 2025-12-19-autonomous-review-and-unified-cli.md

Co-Authored-By: Warp <agent@warp.dev>