### PR TITLE
feat: add monospace.studio footer attribution

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,5 @@
+<footer>
+  <p>
+    A project by <a href="https://monospace.studio" target="_blank" rel="noopener">monospace.studio</a>
+  </p>
+</footer>


### PR DESCRIPTION
Adds custom footer with attribution to monospace.studio.

## Changes
- Created `_includes/footer.html` to override Hitchens theme default footer
- Added "A project by monospace.studio" with link to https://monospace.studio
- Link opens in new tab with security attributes

## Result
✅ Footer displays on all pages  
✅ Links to monospace.studio  
✅ Clean, simple attribution

Co-Authored-By: Warp <agent@warp.dev>