### PR TITLE
fix: improve footer styling and center dividers

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,7 @@
-<footer>
-  <p>
-    A project by <a href="https://monospace.studio" target="_blank" rel="noopener">monospace.studio</a>
-  </p>
+<footer class="site-footer">
+  <div class="wrapper">
+    <p style="text-align: center;">
+      A project by <a href="https://monospace.studio" target="_blank" rel="noopener">monospace.studio</a>
+    </p>
+  </div>
 </footer>

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,32 @@
+/* Center decorative dividers */
+.post-content hr,
+.page-content hr,
+hr {
+  text-align: center;
+  margin: 2rem auto;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Footer styling */
+.site-footer {
+  text-align: center;
+  margin-top: 4rem;
+  padding: 2rem 0;
+  border-top: 1px solid #e8e8e8;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+.site-footer a {
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+}
+
+.site-footer a:hover {
+  border-bottom-width: 2px;
+}


### PR DESCRIPTION
Improves footer styling and centers decorative dividers on post pages.

## Changes

### Footer
- Added proper Hitchens theme classes (`site-footer`, `wrapper`)
- Centered footer text
- Added proper link styling with underline on hover
- Added top border to separate from content

### Dividers
- Created `assets/css/custom.css` with centered HR styling
- Created `_includes/head-custom.html` to load custom CSS
- Decorative dividers now center-aligned

## Result
✅ Footer displays centered with monospace.studio link  
✅ Decorative dividers (horizontal rules) are centered  
✅ Consistent styling with Hitchens theme  
✅ Clean, professional appearance

Co-Authored-By: Warp <agent@warp.dev>