### PR TITLE
fix: avoid nx-dev-infra collisions + clean organism templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ git submodule add https://github.com/derrybirkett/pip.git .pip
 
 # Bootstrap your documentation
 mkdir -p docs
-cp .pip/docs/activity-log.md docs/
-cp .pip/docs/changelog.md docs/
+cp .pip/docs/templates/organism-activity-log.md docs/activity-log.md
+cp .pip/docs/templates/organism-changelog.md docs/changelog.md
 cp .pip/mission/mission.md docs/mission.md
 
 # Edit these files for YOUR project

--- a/bin/apply-nx-dev-infra.sh
+++ b/bin/apply-nx-dev-infra.sh
@@ -68,10 +68,13 @@ echo "✨ Nx + Docker dev scaffold applied successfully!"
 echo
 echo "Next steps:"
 echo "  1. Run: nx run infra:up"
-echo "  2. Then: docker exec -it monospace-dev bash"
-echo "  3. Inside container: pnpm install, nx serve web, etc."
+echo "  2. Then: docker compose exec dev bash"
+echo "  3. Inside container: pnpm install, nx graph, nx <targets>, etc."
 echo
 echo "Services:"
-echo "  • PostgreSQL: localhost:5432 (nexus/nexus)"
-echo "  • n8n: http://localhost:5678"
+echo "  • PostgreSQL: localhost:${POSTGRES_PORT:-5432} (db/user/pass: nexus)"
+echo "  • n8n: http://localhost:${N8N_PORT:-5678}"
+echo
+echo "Port overrides (optional):"
+echo "  • POSTGRES_PORT=5433 N8N_PORT=5679 nx run infra:up"
 echo

--- a/bin/bootstrap-project.sh
+++ b/bin/bootstrap-project.sh
@@ -133,12 +133,12 @@ EOF
 echo -e "${GREEN}✅ Created docs/mission.md${NC}"
 
 # Copy activity log and changelog templates
-cp .pip/docs/activity-log.md docs/activity-log.md
+cp .pip/docs/templates/organism-activity-log.md docs/activity-log.md
 echo -e "${GREEN}✅ Created docs/activity-log.md${NC}"
 
-cp .pip/docs/changelog.md docs/changelog.md
+cp .pip/docs/templates/organism-changelog.md docs/changelog.md
 # Customize changelog with project name
-sed -i '' "s/All notable changes to the website\/app are documented here./All notable changes to ${PROJECT_NAME} are documented here./" docs/changelog.md
+sed -i '' "s/\[Project Name\]/${PROJECT_NAME}/g" docs/changelog.md
 echo -e "${GREEN}✅ Created docs/changelog.md${NC}"
 
 # Create README.md

--- a/docs/templates/organism-activity-log.md
+++ b/docs/templates/organism-activity-log.md
@@ -1,0 +1,7 @@
+# Activity Log
+
+Log new agent activity for each commit: who did what and why.
+
+| Date (UTC) | Agent | Commit/PR | What changed | Why (rationale) | Links |
+| --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD | <agent> | <hash or #PR> | <summary> | <decision/assumption> | <issue/docs> |

--- a/docs/templates/organism-changelog.md
+++ b/docs/templates/organism-changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to [Project Name] are documented here.
+
+## Unreleased

--- a/docs/using-pip-as-genome.md
+++ b/docs/using-pip-as-genome.md
@@ -66,10 +66,10 @@ Copy template structure from `.pip` to create your project's docs:
 mkdir -p docs
 
 # Copy activity log template
-cp .pip/docs/activity-log.md docs/activity-log.md
+cp .pip/docs/templates/organism-activity-log.md docs/activity-log.md
 
 # Copy changelog template
-cp .pip/docs/changelog.md docs/changelog.md
+cp .pip/docs/templates/organism-changelog.md docs/changelog.md
 
 # Copy blog structure if needed
 cp -r .pip/docs/blog docs/blog

--- a/fragments/nx-dev-infra/README.md
+++ b/fragments/nx-dev-infra/README.md
@@ -52,7 +52,7 @@ nx run infra:down
 
 ```bash
 # Enter dev container
-docker exec -it monospace-dev bash
+docker compose exec dev bash
 
 # Inside container
 pnpm install
@@ -75,15 +75,15 @@ your-project/
 ## Services
 
 ### PostgreSQL (db)
-- **Port**: 5432
+- **Port**: 5432 by default (override with `POSTGRES_PORT`)
 - **Database**: nexus
 - **User**: nexus
 - **Password**: nexus
-- **Connection**: `postgresql://nexus:nexus@localhost:5432/nexus`
+- **Connection**: `postgresql://nexus:nexus@localhost:${POSTGRES_PORT:-5432}/nexus`
 
 ### n8n (workflow automation)
-- **Port**: 5678
-- **URL**: http://localhost:5678
+- **Port**: 5678 by default (override with `N8N_PORT`)
+- **URL**: http://localhost:5678 (or `http://localhost:$N8N_PORT`)
 - **Auth**: Disabled for local dev
 - **Database**: Uses PostgreSQL above
 
@@ -144,7 +144,13 @@ docker compose up --build -d
 ```
 
 ### Port conflicts
-Edit `docker-compose.yml` and change port mappings:
+If `5432` is already in use (common if you already have Postgres running), override the port:
+
+```bash
+POSTGRES_PORT=5433 nx run infra:up
+```
+
+Or edit `docker-compose.yml` and change port mappings:
 ```yaml
 ports:
   - "5433:5432"  # Changed from 5432:5432

--- a/fragments/nx-dev-infra/files/docker-compose.yml
+++ b/fragments/nx-dev-infra/files/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: monospace-dev
     working_dir: /workspace
     volumes:
       - .:/workspace
@@ -11,19 +10,17 @@ services:
 
   db:
     image: postgres:16
-    container_name: nexus-db
     environment:
       POSTGRES_DB: nexus
       POSTGRES_USER: nexus
       POSTGRES_PASSWORD: nexus
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 
   n8n:
     image: n8nio/n8n
-    container_name: nexus-n8n
     depends_on:
       - db
     environment:
@@ -34,7 +31,7 @@ services:
       DB_POSTGRESDB_PASSWORD: nexus
       N8N_BASIC_AUTH_ACTIVE: "false"
     ports:
-      - "5678:5678"
+      - "${N8N_PORT:-5678}:5678"
     volumes:
       - n8n_data:/home/node/.n8n
 


### PR DESCRIPTION
## Summary

- Remove hard-coded Docker Compose container names from the nx-dev-infra fragment (prevents cross-project name conflicts).
- Allow overriding Postgres and n8n host ports via `POSTGRES_PORT` / `N8N_PORT` (prevents common local port conflicts).
- Add clean downstream (organism) templates for activity log + changelog, and update bootstrap + docs to use them (avoids copying pip's own history into new projects).

## Changes

- `fragments/nx-dev-infra/files/docker-compose.yml`: drop `container_name`, add env-var port defaults.
- `bin/apply-nx-dev-infra.sh` + `fragments/nx-dev-infra/README.md`: update instructions to use `docker compose exec` and document overrides.
- `docs/templates/organism-*.md`: new clean templates.
- `bin/bootstrap-project.sh`, `docs/using-pip-as-genome.md`, `README.md`: copy/use the organism templates for downstream projects.

## Test Plan

- `bash -n` on modified scripts.
- `docker compose ... config` on the fragment compose template.