### PR TITLE
feat: scaffold Nx product surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Bootstrap new projects with reusable infrastructure scaffolds:
 # In your new project
 git submodule add git@github.com:derrybirkett/pip.git .pip
 ./.pip/bin/apply-nx-dev-infra.sh
+
+# Scaffold common product surfaces (app + marketing + auth boundary)
+./.pip/bin/apply-nx-product-surfaces.sh
 ```
 
 See [Fragments Guide](./docs/fragments-guide.md) for more.

--- a/bin/apply-nx-product-surfaces.sh
+++ b/bin/apply-nx-product-surfaces.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PIP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="$(pwd)"
+
+echo "🚀 Scaffolding Nx product surfaces (app + marketing + auth boundary)"
+echo "   From: $PIP_DIR"
+echo "   Into: $TARGET_DIR"
+echo
+
+if [ ! -f "$TARGET_DIR/nx.json" ]; then
+  echo "❌ Nx workspace not detected (nx.json missing)."
+  echo "   Initialize Nx first (example):"
+  echo "     npx nx@latest init --integrated"
+  exit 1
+fi
+
+if [ ! -f "$TARGET_DIR/package.json" ]; then
+  echo "❌ package.json missing."
+  echo "   Nx init should create it; please run Nx init first."
+  exit 1
+fi
+
+detect_pm() {
+  if [ -f "pnpm-lock.yaml" ]; then
+    echo "pnpm"
+  elif [ -f "yarn.lock" ]; then
+    echo "yarn"
+  else
+    echo "npm"
+  fi
+}
+
+PM="$(detect_pm)"
+
+pm_add_dev() {
+  case "$PM" in
+    pnpm) pnpm add -D "$@" ;;
+    yarn) yarn add -D "$@" ;;
+    npm) npm install -D "$@" ;;
+    *)
+      echo "❌ Unsupported package manager: $PM";
+      exit 1
+      ;;
+  esac
+}
+
+has_dep() {
+  local name="$1"
+  node -e "const p=require('./package.json');const d={...(p.dependencies||{}),...(p.devDependencies||{})};process.exit(d[name]?0:1)" "$name" >/dev/null 2>&1
+}
+
+ensure_nx_react() {
+  if has_dep "@nx/react" && has_dep "@nx/vite"; then
+    echo "✅ Nx React tooling already installed (@nx/react, @nx/vite)"
+    return
+  fi
+
+  echo "📦 Installing Nx React tooling (@nx/react, @nx/vite)..."
+  pm_add_dev @nx/react @nx/vite
+}
+
+NX_INTERACTIVE=false
+export NX_INTERACTIVE
+
+NX_CMD="npx nx"
+
+ensure_nx_react
+
+echo
+
+echo "🧱 Creating apps/app (product app surface)..."
+if [ -d "apps/app" ]; then
+  echo "⚠️  apps/app already exists, skipping"
+else
+  $NX_CMD g @nx/react:application apps/app \
+    --bundler=vite \
+    --linter=eslint \
+    --unitTestRunner=vitest \
+    --e2eTestRunner=none \
+    --routing=false \
+    --style=css \
+    --port=4200 \
+    --skipFormat
+  echo "✅ Created apps/app"
+fi
+
+echo
+
+echo "🧱 Creating apps/marketing (marketing surface)..."
+if [ -d "apps/marketing" ]; then
+  echo "⚠️  apps/marketing already exists, skipping"
+else
+  $NX_CMD g @nx/react:application apps/marketing \
+    --bundler=vite \
+    --linter=eslint \
+    --unitTestRunner=vitest \
+    --e2eTestRunner=none \
+    --routing=false \
+    --style=css \
+    --port=4201 \
+    --skipFormat
+  echo "✅ Created apps/marketing"
+fi
+
+echo
+
+echo "🧱 Creating libs/auth (provider-swappable boundary)..."
+if [ -d "libs/auth" ]; then
+  echo "⚠️  libs/auth already exists, skipping"
+else
+  $NX_CMD g @nx/js:library libs/auth \
+    --bundler=tsc \
+    --linter=eslint \
+    --unitTestRunner=none \
+    --minimal \
+    --skipFormat
+  echo "✅ Created libs/auth"
+fi
+
+echo
+
+echo "📚 Adding organism graph templates under docs/graph/..."
+mkdir -p docs/graph
+
+copy_graph() {
+  local name="$1"
+  local src="$PIP_DIR/graph/$name.md"
+  local dst="$TARGET_DIR/docs/graph/$name.md"
+
+  if [ -f "$dst" ]; then
+    echo "⚠️  docs/graph/$name.md already exists, skipping"
+    return
+  fi
+
+  if [ ! -f "$src" ]; then
+    echo "⚠️  Missing template: $src (skipping)"
+    return
+  fi
+
+  cp "$src" "$dst"
+  echo "✅ Created docs/graph/$name.md"
+}
+
+copy_graph "product-app"
+copy_graph "marketing-website"
+copy_graph "blog"
+
+echo
+
+echo "✨ Product surfaces scaffold complete!"
+echo
+
+echo "Next steps:"
+echo "  1) (Optional) Apply infra: ./.pip/bin/apply-nx-dev-infra.sh"
+echo "  2) Start app: nx serve app"
+echo "  3) Start marketing: nx serve marketing"
+echo "  4) Choose auth provider later by implementing an adapter behind libs/auth"
+echo ""

--- a/bin/bootstrap-project.sh
+++ b/bin/bootstrap-project.sh
@@ -175,17 +175,26 @@ This project uses \`.pip\` as an immutable template (genome):
 
 ## Getting Started
 
-\`\`\`bash
-# Initialize Nx workspace
-npx nx@latest init --integrated
-pnpm init
-pnpm add -D nx @nx/workspace
+### Option A: Docs-only (start lean)
 
-# Apply infrastructure fragment
+- Customize your mission: \`docs/mission.md\`
+- Keep your activity log + changelog current as you ship
+
+### Option B: Nx SaaS scaffold (marketing + app + auth boundary)
+
+\`\`\`bash
+# Initialize Nx (if not already)
+npx nx@latest init --integrated
+
+# (Optional) Dev infra
 ./.pip/bin/apply-nx-dev-infra.sh
 
-# Start development environment
-nx run infra:up
+# Product surfaces
+./.pip/bin/apply-nx-product-surfaces.sh
+
+# Run
+nx serve app
+nx serve marketing
 \`\`\`
 
 ## Status
@@ -223,9 +232,10 @@ echo "  • Cursor AI rules (.cursorrules)"
 echo
 echo -e "${YELLOW}Next steps:${NC}"
 echo "  1. Review and customize docs/mission.md"
-echo "  2. Initialize Nx: npx nx@latest init --integrated"
-echo "  3. Apply infrastructure: ./.pip/bin/apply-nx-dev-infra.sh"
-echo "  4. Start building!"
+echo "  2. (Optional) Initialize Nx: npx nx@latest init --integrated"
+echo "  3. (Optional) Apply infra: ./.pip/bin/apply-nx-dev-infra.sh"
+echo "  4. Scaffold product surfaces: ./.pip/bin/apply-nx-product-surfaces.sh"
+echo "  5. Start app + marketing: nx serve app / nx serve marketing"
 echo
 echo -e "${BLUE}Happy building! 🚀${NC}"
 echo

--- a/docs/fragments-guide.md
+++ b/docs/fragments-guide.md
@@ -35,6 +35,19 @@ Containerized Nx development environment with Postgres and n8n.
 
 [Full documentation →](../fragments/nx-dev-infra/README.md)
 
+### nx-product-surfaces
+Scaffolds common product surfaces in an Nx workspace.
+
+**Provides:**
+- `apps/app` (logged-in product surface)
+- `apps/marketing` (marketing surface)
+- `libs/auth` (provider-swappable auth boundary)
+- `docs/graph/*` templates copied into your organism
+
+**When to use:** Starting a SaaS-style product that will need marketing + app + auth.
+
+[Full documentation →](../fragments/nx-product-surfaces/README.md)
+
 ### astro-blog
 Fast, SEO-friendly blog powered by Astro with Tailwind CSS.
 

--- a/fragments/nx-product-surfaces/README.md
+++ b/fragments/nx-product-surfaces/README.md
@@ -1,0 +1,34 @@
+# nx-product-surfaces (Nx Product Surfaces Scaffold)
+
+Scaffolds the common SaaS “surfaces” in an Nx workspace:
+
+- `apps/app` — Logged-in product app surface
+- `apps/marketing` — Marketing website surface
+- `libs/auth` — Provider-swappable auth boundary (implement Supabase/Clerk/WorkOS later)
+- `docs/graph/*` — Copies graph templates into your organism so you can customize them
+
+## Why this exists
+
+Most products end up needing at least:
+- a marketing surface,
+- a logged-in app surface,
+- and authentication.
+
+This fragment keeps the initial shape consistent while staying lean (it uses Nx generators instead of vendoring huge templates).
+
+## Usage
+
+From your organism project root:
+
+```bash
+# Initialize Nx first (if needed)
+npx nx@latest init --integrated
+
+# Scaffold surfaces
+./.pip/bin/apply-nx-product-surfaces.sh
+```
+
+## Notes
+
+- This script installs `@nx/react` and `@nx/vite` if missing.
+- Auth is intentionally **not tied** to a provider. Treat `libs/auth` as the seam so you can switch Supabase ↔ Clerk ↔ WorkOS later.


### PR DESCRIPTION
Adds a guided scaffold for the common SaaS surfaces in an Nx workspace.

- New script: `bin/apply-nx-product-surfaces.sh`
  - Generates `apps/app`, `apps/marketing`, and `libs/auth` (provider-swappable seam)
  - Copies graph templates into organism `docs/graph/*`
  - Installs `@nx/react` + `@nx/vite` if missing

- Docs: mention the new scaffold in `docs/fragments-guide.md` and `README.md`
- Bootstrap: README/next-steps now point to the new scaffold

Why: most organisms need marketing + app + auth; this makes the intended shape discoverable without vendoring heavy templates.
