### PR TITLE
Bootstrap: seed docs hygiene workflow into organisms

### DIFF
--- a/bin/bootstrap-project.sh
+++ b/bin/bootstrap-project.sh
@@ -147,6 +147,19 @@ if [ -f ".pip/docs/templates/organism-agentic.md" ]; then
   echo -e "${GREEN}✅ Created docs/agentic.md${NC}"
 fi
 
+# Seed GitHub repo hygiene (workflows + PR template)
+mkdir -p .github/workflows
+
+if [ -f ".pip/docs/templates/organism-validate-docs.yml" ]; then
+  cp .pip/docs/templates/organism-validate-docs.yml .github/workflows/validate-docs.yml
+  echo -e "${GREEN}✅ Created .github/workflows/validate-docs.yml${NC}"
+fi
+
+if [ -f ".pip/docs/templates/organism-pull-request-template.md" ]; then
+  cp .pip/docs/templates/organism-pull-request-template.md .github/PULL_REQUEST_TEMPLATE.md
+  echo -e "${GREEN}✅ Created .github/PULL_REQUEST_TEMPLATE.md${NC}"
+fi
+
 # Create README.md
 cat > README.md << EOF
 # ${PROJECT_NAME}
@@ -235,6 +248,8 @@ echo "  • Mission statement (docs/mission.md)"
 echo "  • Activity log (docs/activity-log.md)"
 echo "  • Changelog (docs/changelog.md)"
 echo "  • Agentic workflow playbook (docs/agentic.md)"
+echo "  • Docs hygiene workflow (.github/workflows/validate-docs.yml)"
+echo "  • Pull request template (.github/PULL_REQUEST_TEMPLATE.md)"
 echo "  • README with your project story"
 echo "  • Cursor AI rules (.cursorrules)"
 echo

--- a/docs/github-branch-protection.md
+++ b/docs/github-branch-protection.md
@@ -28,7 +28,8 @@ main
 #### ✅ Require status checks to pass before merging
 - [x] **Require branches to be up to date before merging**
 - Status checks to require:
-  - *(Add any CI/CD checks here as they're configured)*
+  - **Docs hygiene** *(from `.github/workflows/validate-docs.yml` in bootstrapped projects)*
+  - *(Add any additional CI/CD checks here as they're configured)*
 
 **Rationale**: Prevents merging broken code and ensures compatibility with latest main.
 

--- a/docs/templates/organism-pull-request-template.md
+++ b/docs/templates/organism-pull-request-template.md
@@ -1,0 +1,65 @@
+## Goal
+<!-- What are you trying to accomplish? One sentence is best. -->
+
+## Scope
+<!-- What's included and what's not? -->
+
+### Changes Made
+- 
+- 
+- 
+
+### Out of Scope
+- 
+- 
+
+## Context
+<!-- Why are we making this change? Link to issues, discussions, or docs. -->
+
+**Related Issues**:
+- Closes #
+- Related to #
+
+**Related Docs**:
+- docs/
+- 
+
+## Testing
+
+### Test Plan
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] E2E tests added/updated (if applicable)
+- [ ] Manual testing completed
+
+### Manual Testing Steps
+1. 
+2. 
+3. 
+
+## Risks & Considerations
+
+### Potential Risks
+- 
+
+### Migration Required?
+- [ ] Yes (describe below)
+- [ ] No
+
+### Breaking Changes?
+- [ ] Yes (describe below)
+- [ ] No
+
+## Documentation Updates
+- [ ] Activity log updated (docs/activity-log.md)
+- [ ] Changelog updated (docs/changelog.md)
+- [ ] README updated (if applicable)
+
+## Checklist
+- [ ] Code follows project style and standards
+- [ ] All tests passing
+- [ ] No new linting errors
+- [ ] Activity log updated
+- [ ] Changelog updated (if user-facing)
+- [ ] Proper branch name used (feat/, fix/, docs/, chore/)
+- [ ] Commits reference issues where applicable

--- a/docs/templates/organism-validate-docs.yml
+++ b/docs/templates/organism-validate-docs.yml
@@ -1,0 +1,80 @@
+name: Validate Activity Log & Changelog
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs-hygiene:
+    name: Docs hygiene
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate activity log / changelog updated
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            base_ref="origin/${GITHUB_BASE_REF}"
+            git fetch --no-tags origin "${GITHUB_BASE_REF}" --depth=1
+            range="${base_ref}...HEAD"
+          else
+            before="${GITHUB_EVENT_BEFORE:-}"
+            after="${GITHUB_SHA:-}"
+            if [[ -n "$before" && -n "$after" && "$before" != "0000000000000000000000000000000000000000" ]]; then
+              range="${before}...${after}"
+            else
+              range="HEAD~1...HEAD"
+            fi
+          fi
+
+          echo "Diff range: ${range}"
+          changed_files=$(git diff --name-only "$range" | sed '/^$/d' || true)
+
+          if [[ -z "$changed_files" ]]; then
+            echo "No changed files detected; skipping."
+            exit 0
+          fi
+
+          activity_log="docs/activity-log.md"
+          changelog="docs/changelog.md"
+
+          activity_touched=false
+          changelog_touched=false
+
+          if echo "$changed_files" | grep -qx "$activity_log"; then activity_touched=true; fi
+          if echo "$changed_files" | grep -qx "$changelog"; then changelog_touched=true; fi
+
+          # Require activity-log update for any substantive (non-docs-only) change.
+          # Docs-only changes are allowed without updating the activity log.
+          non_docs_changes=$(echo "$changed_files" | grep -Ev '^(docs/|README\.md$|\.github/)' || true)
+
+          if [[ -n "$non_docs_changes" && "$activity_touched" != "true" ]]; then
+            echo "::error::Substantive changes detected but docs/activity-log.md was not updated."
+            echo "Please add a row to docs/activity-log.md describing what changed and why."
+            echo "Substantive files:"
+            echo "$non_docs_changes"
+            exit 1
+          fi
+
+          # Require changelog update when likely user-facing code changed.
+          # This is heuristic; adjust path patterns per project conventions.
+          user_facing_changes=$(echo "$changed_files" | grep -E '^(apps/|packages/|libs/|src/|web/|frontend/|backend/|api/)' || true)
+
+          if [[ -n "$user_facing_changes" && "$changelog_touched" != "true" ]]; then
+            echo "::error::Likely user-facing code changed but docs/changelog.md was not updated."
+            echo "Please add an entry under 'Unreleased' in docs/changelog.md (or justify why not user-facing)."
+            echo "User-facing files:"
+            echo "$user_facing_changes"
+            exit 1
+          fi
+
+          echo "✅ Docs hygiene checks passed."


### PR DESCRIPTION
## Goal
Make `.pip` bootstrapped organisms automatically enforce the "update activity log + changelog" policy via a GitHub Actions status check, and provide a PR template that points at the organism docs (not `.pip`).

## What changed
- Added template workflow: `docs/templates/organism-validate-docs.yml`
- Added template PR template: `docs/templates/organism-pull-request-template.md`
- Updated bootstrap to copy both into new organisms:
  - `.github/workflows/validate-docs.yml`
  - `.github/PULL_REQUEST_TEMPLATE.md`
- Updated branch protection docs to recommend requiring the **Docs hygiene** status check

## Notes
- The changelog requirement is heuristic (path-based). Projects can adjust patterns in their copied workflow.
