### PR TITLE
chore: seed dev + security templates

### DIFF
--- a/bin/bootstrap-project.sh
+++ b/bin/bootstrap-project.sh
@@ -7,6 +7,19 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+ensure_line_in_file() {
+  local line="$1"
+  local file="$2"
+
+  if [ ! -f "$file" ]; then
+    touch "$file"
+  fi
+
+  if ! grep -qxF "$line" "$file"; then
+    echo "$line" >> "$file"
+  fi
+}
+
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                                                                ║${NC}"
 echo -e "${BLUE}║              .pip Project Bootstrap Assistant                  ║${NC}"
@@ -147,6 +160,44 @@ if [ -f ".pip/docs/templates/organism-agentic.md" ]; then
   echo -e "${GREEN}✅ Created docs/agentic.md${NC}"
 fi
 
+# Seed development guide
+if [ -f ".pip/docs/templates/organism-dev.md" ]; then
+  cp .pip/docs/templates/organism-dev.md docs/dev.md
+  echo -e "${GREEN}✅ Created docs/dev.md${NC}"
+fi
+
+# Seed local env conventions (direnv)
+if [ -f ".pip/docs/templates/organism-envrc.example" ]; then
+  cp .pip/docs/templates/organism-envrc.example .envrc.example
+  echo -e "${GREEN}✅ Created .envrc.example${NC}"
+  ensure_line_in_file ".envrc" ".gitignore"
+  ensure_line_in_file ".direnv/" ".gitignore"
+fi
+
+# Seed SECURITY.md
+if [ -f ".pip/docs/templates/organism-security.md" ]; then
+  cp .pip/docs/templates/organism-security.md SECURITY.md
+  echo -e "${GREEN}✅ Created SECURITY.md${NC}"
+fi
+
+# Seed GitHub issue templates + CODEOWNERS stub
+mkdir -p .github/ISSUE_TEMPLATE
+
+if [ -f ".pip/docs/templates/organism-issue-bug.yml" ]; then
+  cp .pip/docs/templates/organism-issue-bug.yml .github/ISSUE_TEMPLATE/bug_report.yml
+  echo -e "${GREEN}✅ Created .github/ISSUE_TEMPLATE/bug_report.yml${NC}"
+fi
+
+if [ -f ".pip/docs/templates/organism-issue-feature.yml" ]; then
+  cp .pip/docs/templates/organism-issue-feature.yml .github/ISSUE_TEMPLATE/feature_request.yml
+  echo -e "${GREEN}✅ Created .github/ISSUE_TEMPLATE/feature_request.yml${NC}"
+fi
+
+if [ -f ".pip/docs/templates/organism-codeowners" ]; then
+  cp .pip/docs/templates/organism-codeowners .github/CODEOWNERS
+  echo -e "${GREEN}✅ Created .github/CODEOWNERS${NC}"
+fi
+
 # Seed GitHub repo hygiene (workflows + PR template)
 mkdir -p .github/workflows
 
@@ -248,8 +299,12 @@ echo "  • Mission statement (docs/mission.md)"
 echo "  • Activity log (docs/activity-log.md)"
 echo "  • Changelog (docs/changelog.md)"
 echo "  • Agentic workflow playbook (docs/agentic.md)"
+echo "  • Dev guide template (docs/dev.md)"
+echo "  • Local env example (.envrc.example)"
+echo "  • Security policy (SECURITY.md)"
 echo "  • Docs hygiene workflow (.github/workflows/validate-docs.yml)"
 echo "  • Pull request template (.github/PULL_REQUEST_TEMPLATE.md)"
+echo "  • Issue templates + CODEOWNERS stub (.github/*)"
 echo "  • README with your project story"
 echo "  • Cursor AI rules (.cursorrules)"
 echo

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to the website/app are documented here.
 
 ## Unreleased
 
+### Added
+- Bootstrap now seeds:
+  - `docs/dev.md` (dev commands via Nx)
+  - `.envrc.example` + `.gitignore` entries for `direnv` (`.envrc`, `.direnv/`)
+  - `SECURITY.md`, `.github/CODEOWNERS`, and GitHub issue templates
+
 ## 2025-12-30 — Organism Bootstrap & Nx Scaffolds
 ### Added
 - **Nx Product Surfaces Scaffold** (`bin/apply-nx-product-surfaces.sh`)

--- a/docs/templates/organism-codeowners
+++ b/docs/templates/organism-codeowners
@@ -1,0 +1,6 @@
+# CODEOWNERS (optional)
+#
+# Add owners here to enable "Require review from Code Owners" later.
+#
+# Example:
+# * @your-org/your-team

--- a/docs/templates/organism-dev.md
+++ b/docs/templates/organism-dev.md
@@ -1,0 +1,35 @@
+# Development
+
+This doc is a starter template. Keep it accurate as you evolve your repo.
+
+## Prerequisites
+
+- Node.js + package manager (pnpm recommended)
+- Optional: `direnv` for local environment variables
+
+## Run (recommended)
+
+Prefer Nx targets over running tools directly from subfolders.
+
+```bash
+# App
+npx nx serve app
+
+# API (if present)
+npx nx serve api
+```
+
+## Tests
+
+```bash
+# Unit tests
+npx nx test app
+
+# E2E (if configured)
+npx nx e2e app-e2e
+```
+
+## Local environment variables
+
+- Copy `.envrc.example` → `.envrc` and fill in values.
+- `.envrc` is intentionally gitignored.

--- a/docs/templates/organism-envrc.example
+++ b/docs/templates/organism-envrc.example
@@ -1,0 +1,12 @@
+# Example direnv file.
+#
+# Usage:
+#   cp .envrc.example .envrc
+#   direnv allow
+
+# Avoid overriding GitHub CLI auth (these env vars can cause confusing failures).
+unset GH_TOKEN
+unset GITHUB_TOKEN
+
+# Add your local secrets below.
+# export SOME_API_KEY="..."

--- a/docs/templates/organism-issue-bug.yml
+++ b/docs/templates/organism-issue-bug.yml
@@ -1,0 +1,33 @@
+name: Bug report
+description: Report something that is broken
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS / browser / node version, etc.

--- a/docs/templates/organism-issue-feature.yml
+++ b/docs/templates/organism-issue-feature.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Propose an improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem are we solving?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should we build?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...

--- a/docs/templates/organism-security.md
+++ b/docs/templates/organism-security.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you’ve found a security vulnerability, please do not open a public issue.
+
+Instead, contact the maintainers privately with:
+
+- a description of the issue
+- steps to reproduce
+- impact assessment (what could an attacker do?)
+- any suggested fixes or mitigations
+
+We will acknowledge receipt and work on a fix.


### PR DESCRIPTION
Improves  bootstraps with a few high-leverage defaults:

- Seed  template (run via Nx targets)
- Seed  + add  and  to 
- Seed 
- Seed  stub
- Seed basic GitHub issue templates (bug + feature)

Also documents the change in  (Unreleased).