### PR TITLE
feat: add Nx wrappers and PIP_MODE guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,14 @@ Thumbs.db
 *.log
 *.tmp
 
+# Node / Nx artifacts
+node_modules/
+.nx/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
 # Jekyll build artifacts
 .bundle/
 vendor/

--- a/WARP.md
+++ b/WARP.md
@@ -159,6 +159,15 @@ Default: Squash and merge to keep main history clean
    - Features: activity log + changelog + blog
    - Major releases: full wrap-up
 
+## Execution Modes (PIP_MODE)
+
+When using the unified CLI (`bin/pip`), set `PIP_MODE` explicitly:
+
+- `PIP_MODE=observe` or `PIP_MODE=propose` for exploration and planning
+- `PIP_MODE=execute` only after you have explicit approval to run commands that modify files or branches
+
+Side-effecting commands like `pip apply`, `pip bootstrap`, `pip wrap`, and `pip review` are blocked unless `PIP_MODE=execute`.
+
 ### Testing Strategy
 - **Playwright** for E2E testing (user preference from rules)
 - Unit tests: 80%+ coverage for business logic

--- a/bin/pip
+++ b/bin/pip
@@ -10,6 +10,23 @@ set -e
 VERSION="1.0.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Execution mode (agent guardrails)
+# - observe: read-only, no side effects
+# - propose: read-only, requires explicit approval before execution
+# - execute: allow commands that write files or create branches
+PIP_MODE_RAW="${PIP_MODE:-execute}"
+PIP_MODE="$(echo "$PIP_MODE_RAW" | tr '[:upper:]' '[:lower:]')"
+
+case "$PIP_MODE" in
+    observe|propose|execute)
+        ;;
+    *)
+        echo -e "${RED}Error: Invalid PIP_MODE '$PIP_MODE_RAW'${NC}"
+        echo -e "Allowed: observe | propose | execute"
+        exit 2
+        ;;
+esac
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -24,6 +41,10 @@ show_help() {
     echo -e ""
     echo -e "${GREEN}USAGE:${NC}"
     echo -e "    pip <command> [options]"
+    echo -e ""
+    echo -e "${GREEN}MODES:${NC}"
+    echo -e "    Set ${YELLOW}PIP_MODE${NC} to control execution: observe | propose | execute"
+    echo -e "    Current: ${YELLOW}${PIP_MODE}${NC}"
     echo -e ""
     echo -e "${GREEN}COMMANDS:${NC}"
     echo -e ""
@@ -74,6 +95,17 @@ show_help() {
     echo -e "${GREEN}DOCS:${NC}"
     echo -e "    Full documentation: README.md, WARP.md"
     echo -e "    Pattern library: resources/agentic-design-patterns/extracted-patterns/"
+}
+
+require_execute() {
+    local command_name="$1"
+
+    if [ "$PIP_MODE" != "execute" ]; then
+        echo -e "${YELLOW}Blocked:${NC} '${command_name}' requires execution approval."
+        echo -e "Set ${YELLOW}PIP_MODE=execute${NC} and re-run to proceed."
+        echo -e "Current: ${YELLOW}PIP_MODE=${PIP_MODE}${NC}"
+        exit 3
+    fi
 }
 
 show_version() {
@@ -174,6 +206,7 @@ show_pattern() {
 # Main command router
 case "${1:-help}" in
     review)
+        require_execute "review"
         shift
         exec "$SCRIPT_DIR/review-and-prioritize.sh" "$@"
         ;;
@@ -184,6 +217,7 @@ case "${1:-help}" in
         ;;
     
     wrap|wrap-up)
+        require_execute "wrap"
         shift
         if [ -f "$SCRIPT_DIR/wrap-up.sh" ]; then
             exec "$SCRIPT_DIR/wrap-up.sh" "$@"
@@ -198,6 +232,7 @@ case "${1:-help}" in
         ;;
     
     bootstrap)
+        require_execute "bootstrap"
         shift
         if [ -f "$SCRIPT_DIR/bootstrap-project.sh" ]; then
             exec "$SCRIPT_DIR/bootstrap-project.sh" "$@"
@@ -208,6 +243,7 @@ case "${1:-help}" in
         ;;
     
     apply)
+        require_execute "apply"
         fragment=$2
         shift 2
         if [ -z "$fragment" ]; then

--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -31,6 +31,7 @@ Log new agent activity for each commit: who did what and why.
 | 2025-12-30 | CTO/CPO | PR #47 | Seeded agentic workflow playbook into new projects | Bootstrap now copies docs/agentic.md to organisms; short link-heavy guide explains human-in-the-loop agent workflows, role-based collaboration, and references genome patterns without duplicating framework docs | docs/templates/organism-agentic.md, bin/bootstrap-project.sh |
 | 2025-12-30 | CTO | PR #51 | Bootstrap seeds dev/security templates into organisms | Enable new projects to start with docs/dev.md (dev commands), .envrc.example with .gitignore entries, SECURITY.md, .github/CODEOWNERS, and GitHub issue templates for immediate dev and security hygiene | bin/bootstrap-project.sh, docs/templates/ |
 | 2026-01-05 | CTO | (v2) site extraction | Extracted the public website/blog into a separate `pip-blog` organism repo | Reduce cognitive load and keep this repo focused on the `.pip` kernel (genome); organisms can still inherit governance/tooling via the `.pip` submodule model | docs/changelog.md, ROADMAP.md, README.md |
+| 2026-01-05 | CTO | feat/nx-and-modes-migration | Added Nx workspace wrappers and explicit execution modes (PIP_MODE) | Make agent autonomy explicit at runtime; provide a task runner to orchestrate existing scripts without changing their behavior | package.json, nx.json, project.json, bin/pip, docs/policies/agent-autonomy-guardrails.md, WARP.md |
 | YYYY-MM-DD | <agent> | <hash or #PR> | <summary> | <decision/assumption> | <issue/docs> |
 
 Guidance:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,16 @@ All notable changes to the `.pip` framework are documented here.
 
 ## Unreleased
 
+### Added
+- **Nx workspace wrappers for kernel scripts**
+  - Adds `nx.json` + `project.json` so you can run common tasks via `nx run pip:<target>`
+  - Adds `package.json` with Nx as a dev dependency for contributors working on the kernel repo
+
+### Changed
+- **Unified CLI now supports explicit execution modes via `PIP_MODE`**
+  - `observe`/`propose` block side-effecting commands; `execute` permits them
+  - Side-effecting commands include `pip apply`, `pip bootstrap`, `pip wrap`, and `pip review`
+
 ### Changed
 - **Breaking (v2): extracted the website/blog into a separate `pip-blog` organism repo**
   - Removed Jekyll site files and GitHub Pages publishing workflow from this repo

--- a/docs/policies/agent-autonomy-guardrails.md
+++ b/docs/policies/agent-autonomy-guardrails.md
@@ -23,3 +23,13 @@ Agents must not proceed with their own ideas without explicit permission.
 - Review: request approvals from relevant owners
 - Record: log decision in Activity Log and link in PR
 
+## Execution Modes (PIP_MODE)
+
+To make autonomy explicit at runtime, the unified CLI (`bin/pip`) supports an execution mode:
+
+- `PIP_MODE=observe` — read-only exploration (blocks commands that can write files, create branches, or update logs)
+- `PIP_MODE=propose` — prepare to execute, but do not perform side effects (same blocks as observe)
+- `PIP_MODE=execute` — allowed to run commands that modify the repo
+
+Commands that can cause side effects (e.g. `pip apply`, `pip bootstrap`, `pip wrap`, `pip review`) require `PIP_MODE=execute`.
+

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/nx",
+  "defaultBase": "main",
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*"],
+    "production": ["default"]
+  },
+  "projects": {
+    "pip": {
+      "root": "."
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pip",
+  "private": true,
+  "description": ".pip (Project Intelligence & Process) kernel repo",
+  "scripts": {
+    "nx": "nx"
+  },
+  "devDependencies": {
+    "nx": "^20.3.0"
+  }
+}

--- a/project.json
+++ b/project.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/nx-project",
+  "name": "pip",
+  "projectType": "library",
+  "targets": {
+    "validate": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip validate"
+      }
+    },
+    "patterns": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip patterns"
+      }
+    },
+    "review": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip review"
+      }
+    },
+    "wrap": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip wrap"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a minimal Nx workspace scaffold to orchestrate existing kernel scripts, plus explicit execution modes (PIP_MODE) in the unified pip CLI. Nx targets are wrappers only; underlying scripts unchanged. Docs updated (WARP + autonomy guardrails) and activity log/changelog recorded.