### PR TITLE
chore: add more Nx targets

### DIFF
--- a/project.json
+++ b/project.json
@@ -3,6 +3,18 @@
   "name": "pip",
   "projectType": "library",
   "targets": {
+    "help": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip help"
+      }
+    },
+    "version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip version"
+      }
+    },
     "validate": {
       "executor": "nx:run-commands",
       "options": {
@@ -15,6 +27,12 @@
         "command": "./bin/pip patterns"
       }
     },
+    "test-bootstrap": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/test-bootstrap.sh"
+      }
+    },
     "review": {
       "executor": "nx:run-commands",
       "options": {
@@ -25,6 +43,34 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "./bin/pip wrap"
+      }
+    },
+    "bootstrap": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip bootstrap",
+        "forwardAllArgs": true
+      }
+    },
+    "apply-nx-dev-infra": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip apply nx-dev-infra",
+        "forwardAllArgs": true
+      }
+    },
+    "apply-nx-product-surfaces": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip apply nx-product-surfaces",
+        "forwardAllArgs": true
+      }
+    },
+    "apply-astro-blog": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./bin/pip apply astro-blog",
+        "forwardAllArgs": true
       }
     }
   }


### PR DESCRIPTION
Adds additional Nx targets to wrap existing bin scripts and pip commands (wrappers only). New targets: help, version, test-bootstrap, bootstrap, apply-nx-dev-infra, apply-nx-product-surfaces, apply-astro-blog. Args are forwarded for bootstrap/apply targets via --.