### PR TITLE
fix: pip wrap should operate on organism repo

### DIFF
--- a/bin/wrap-up.sh
+++ b/bin/wrap-up.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KERNEL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# If .pip is used as a git submodule, run wrap-up against the superproject
+# (the organism) rather than the detached submodule checkout.
+SUPERPROJECT_DIR="$(cd "$KERNEL_DIR" && git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+if [[ -n "${SUPERPROJECT_DIR}" ]]; then
+  ROOT_DIR="$SUPERPROJECT_DIR"
+else
+  ROOT_DIR="$KERNEL_DIR"
+fi
 
 DRY_RUN="${PIP_WRAP_UP_DRY_RUN:-0}"
 CONFIRM_DOCS_DEFAULT="${PIP_WRAP_UP_CONFIRM_DOCS:-}"
@@ -23,7 +32,7 @@ check_file(){
 }
 
 echo "=== Wrap-Up Checklist ==="
-check_file "$ROOT_DIR/docs/processes/wrap-up-checklist.md"
+check_file "$KERNEL_DIR/docs/processes/wrap-up-checklist.md"
 check_file "$ROOT_DIR/docs/activity-log.md"
 check_file "$ROOT_DIR/docs/changelog.md"
 echo "Review \"docs/processes/wrap-up-checklist.md\" and ensure every step is complete."

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,9 @@ All notable changes to the `.pip` framework are documented here.
   - `pip` remains the genome/kernel repo; organisms submodule it at `.pip/`
   - The site repo should include `pip` as a submodule if it wants to inherit governance and tooling
 
+### Fixed
+- `pip wrap` now operates on the organism git repository when `.pip` is used as a submodule (instead of acting on the detached submodule checkout)
+
 ## 2026-01-05 — Dev & Security Templates
 ### Added
 - **Bootstrap Dev/Security Templates** (`bin/bootstrap-project.sh`)


### PR DESCRIPTION
## Problem
When `.pip` is installed as a git submodule, the submodule checkout is typically detached. `pip wrap` was running `git status/commit/push` inside the submodule, which is not what organisms want.

## Change
- Detect the superproject working tree via `git rev-parse --show-superproject-working-tree`.
- Run wrap-up git operations against the superproject (organism) when present.
- Continue referencing the kernel wrap-up checklist from `.pip`.

## Notes
This preserves behavior when running inside the kernel repo (no superproject).
