### PR TITLE
fix: Use OPENAI secret instead of OPENAI_API_KEY

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -55,7 +55,7 @@ Add these secrets to your repository:
 
 ```bash
 # Required
-gh secret set OPENAI_API_KEY --body "sk-..."
+gh secret set OPENAI --body "sk-..."
 gh secret set GH_PROJECT_TOKEN --body "ghp_..."
 
 # Optional (for notifications)
@@ -63,7 +63,7 @@ gh secret set SLACK_WEBHOOK_URL --body "https://..."
 ```
 
 **Secret requirements:**
-- `OPENAI_API_KEY`: OpenAI API key with GPT-4 access
+- `OPENAI`: OpenAI API key with GPT-4 access
 - `GH_PROJECT_TOKEN`: GitHub PAT with `repo`, `project`, `workflow` scopes
 - `SLACK_WEBHOOK_URL`: (Optional) For agent notifications
 
@@ -203,7 +203,7 @@ gh issue close 123 --reason "not planned"
 
 **Environment variables:**
 - `GITHUB_TOKEN`: Auto-provided by Actions
-- `OPENAI_API_KEY`: From secrets
+- `OPENAI_API_KEY`: From secrets.OPENAI
 - `PRIORITY_FILTER`: From workflow input (default: p1)
 - `ISSUE_NUMBER`: From workflow input (optional)
 
@@ -364,7 +364,7 @@ gh run view <run-id> --log
 ```
 
 **Common issues:**
-- Missing `OPENAI_API_KEY` secret
+- Missing `OPENAI` secret
 - Insufficient GitHub token permissions
 - No eligible roadmap issues found
 - OpenAI rate limit exceeded

--- a/.github/workflows/autonomous-roadmap-agent.yml
+++ b/.github/workflows/autonomous-roadmap-agent.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run autonomous agent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI }}
           PRIORITY_FILTER: ${{ inputs.priority || 'p1' }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |

--- a/.github/workflows/pr-review-agents.yml
+++ b/.github/workflows/pr-review-agents.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run CTO review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           cd .github/agents
@@ -61,7 +61,7 @@ jobs:
       - name: Run CISO security review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           cd .github/agents


### PR DESCRIPTION
## Issue

The autonomous agent workflow was failing because it was looking for `OPENAI_API_KEY` secret, but the repository has it configured as `OPENAI`.

## Fix

Updated all workflows to use `secrets.OPENAI` instead of `secrets.OPENAI_API_KEY`:
- `autonomous-roadmap-agent.yml`
- `pr-review-agents.yml` (both CTO and CISO reviews)

Also updated documentation in `.github/agents/README.md` to reflect correct secret name.

## Testing

After this merges, the autonomous agent workflow should run successfully with the existing `OPENAI` secret.

Co-Authored-By: Warp <agent@warp.dev>