### PR TITLE
fix: Configure git identity for autonomous agent

### DIFF
--- a/.github/workflows/autonomous-roadmap-agent.yml
+++ b/.github/workflows/autonomous-roadmap-agent.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Issue

Agent workflow was failing at git commit with "Author identity unknown" error.

## Fix

Added git config step to set:
- `user.name`: github-actions[bot]
- `user.email`: github-actions[bot]@users.noreply.github.com

This step runs before the agent creates commits, allowing it to push changes successfully.

Co-Authored-By: Warp <agent@warp.dev>